### PR TITLE
fix: Docker環境下で .env の値を取得できない不具合の修正

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
 
 jobs:
   build:

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
     branches:
       - main
-  merge_group:
 
 jobs:
   build:

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -12,5 +12,5 @@ use std::env;
 /// ```
 pub fn get_env(key: &str) -> String {
     dotenv().ok();
-    env::var(key).unwrap_or_else(|_| panic!("{key} must be set"))
+    env::var(key).unwrap_or_else(|_| panic!("Key:[{key}] value is not set."))
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,7 +2,6 @@ use dotenvy::dotenv;
 use std::env;
 
 /// Returns the value of the environment variable for the Key specified in the first argument.
-/// - If the `.env` file does not exist, an error is returned.
 /// - If the value does not exist, an error is raised and the Key for which the value does not exist is reported by cargo.
 ///
 /// ### Example:

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -12,6 +12,6 @@ use std::env;
 /// }
 /// ```
 pub fn get_env(key: &str) -> String {
-    dotenv().expect(".env file not found");
+    dotenv().ok();
     env::var(key).unwrap_or_else(|_| panic!("{key} must be set"))
 }


### PR DESCRIPTION
### このプルリクエストが解決しようとしていること

close #10
- Docker 環境下で .env の値を取得できない問題を修正

~~- マージキュー機能を使用するために CI のトリガーを修正~~

### 実施内容

Docker 環境下で .env の値を取得できない問題を解決するために、 本来 panic させる必要のないエラー処理を修正しました。

これにより環境変数をシェル側から指定しても動くようになります
